### PR TITLE
Revert "Update Helm release holmes to v0.38.0"

### DIFF
--- a/infrastructure/holmesgpt/helmrelease.yaml
+++ b/infrastructure/holmesgpt/helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: holmes
-      version: '0.38.0'
+      version: '0.36.0'
       sourceRef:
         kind: HelmRepository
         name: robusta


### PR DESCRIPTION
Reverts Almothana12/homelab#701
operator pod crash loops with this error:
                                                               
Traceback (most recent call last):                             
  File "<frozen runpy>", line 198, in _run_module_as_main      
  File "<frozen runpy>", line 88, in _run_code                 
  File "/app/holmes_operator/operator.py", line 10, in <module>
    from holmes.common.env_vars import ENABLE_JSON_LOGS_FORMAT 
ModuleNotFoundError: No module named 'holmes'                  